### PR TITLE
solution for Heroku push error: failed to install bundles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
@@ -259,6 +261,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   autoprefixer-rails (= 10.2.5)


### PR DESCRIPTION
Added darwin config: bundle lock --add-platform x86_64-linux