### PR TITLE
Cloudinary fix for banner (heroku)

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,8 +1,7 @@
 .intro-header { 
     padding-bottom: 100px;
     text-align: center;
-    // background: url('https://res.cloudinary.com/elyse/image/upload/v1627360551/banners/banner_isgqe5.png') no-repeat center center fixed;
-    background-image: url(home-banner.gif);
+    background-image: url('https://res.cloudinary.com/elyse/image/upload/v1627653929/banners/home-banner_bmpbrr.gif');
     background-size: cover;
     height: 100%;
     width: 100%;

--- a/app/views/foodtrucks/_foodtruck-cards.html.erb
+++ b/app/views/foodtrucks/_foodtruck-cards.html.erb
@@ -1,5 +1,5 @@
-<%= button_to "New Foodtruck", new_foodtruck_path(@foodtrucks), :method => :get, class: "btn" %>
 <div class="container-fluid" id="card-container" >
+<h2>All Foodtrucks (<%= @foodtrucks.count%>)</h2>
   <div class="grid" data-isotope='{ "itemSelector": ".card", "layoutMode": "fitRows" }'>
     <% @foodtrucks.each do |foodtruck| %>
       <%= link_to foodtruck_path(foodtruck) do %>


### PR DESCRIPTION
Also removed second 'add foodtruck' link above card container (it's already in navbar).
Added 'All Foodtrucks (count)' title above cards